### PR TITLE
specified height of NavButton to align with logo

### DIFF
--- a/src/components/Navigation/Navigation.js
+++ b/src/components/Navigation/Navigation.js
@@ -9,6 +9,7 @@ const Wrapper = styled.div`
 
 const NavButton = StyledLinkButton.extend`
   @media screen and (max-width: 640px) {
+    height: 100%;
     border: none !important;
     padding: 0;
   }


### PR DESCRIPTION
setting the height of NavButton to align with the height of the logo image ( this is to tailor for the log out button so that it aligns with the Capital On Tap logo)