### PR TITLE
Tabs and ToggleButton enhancement / fixes

### DIFF
--- a/src/components/Tabs/Tabs.js
+++ b/src/components/Tabs/Tabs.js
@@ -36,7 +36,7 @@ const TabsHeaders = styled.div`
   display: flex;
   position: relative;
 `;
- 
+
 const TabsContainer = styled.div`
   margin: ${props => props.margin || '1.4rem'};
   display: flex;
@@ -45,8 +45,9 @@ const TabsContainer = styled.div`
 
 class Tabs extends Component {
   static getDerivedStateFromProps(nextProps, state) {
-    if (nextProps.activeIndex !== state.activeIndex) {
-      return { activeIndex: nextProps.activeIndex }
+    const { controlledActiveIndex } = nextProps
+    if (typeof controlledActiveIndex == 'number' && controlledActiveIndex !== state.activeIndex) {
+      return { activeIndex: controlledActiveIndex }
     } else {
       return null
     }
@@ -56,7 +57,7 @@ class Tabs extends Component {
     super(props);
 
     this.state = {
-      activeIndex: 0
+      activeIndex: props.activeIndex
     };
   }
 
@@ -103,8 +104,10 @@ class Tabs extends Component {
 }
 
 Tabs.propTypes = {
-  /** Active index to enable control of active tab */
+  /** Initial active index to show on component mount */
   activeIndex: PropTypes.number,
+  /** Optional index to control active tab from outside of the component */
+  controlledActiveIndex: PropTypes.number,
   /** Handler to run when the tab is clicked */
   onTabClicked: PropTypes.func,
   /** Child nodes */
@@ -114,6 +117,7 @@ Tabs.propTypes = {
 };
 
 Tabs.defaultProps = {
+  activeIndex: 0,
   onTabClicked: null,
   children: []
 };

--- a/src/components/Tabs/Tabs.stories.js
+++ b/src/components/Tabs/Tabs.stories.js
@@ -40,7 +40,7 @@ class MyComponent extends Component {
     return (
       <Fragment>
         <WidgetBox>
-          <Tabs onTabClicked={this.handleTabClicked} activeIndex={this.state.selectedTab}>
+          <Tabs onTabClicked={this.handleTabClicked} controlledActiveIndex={this.state.selectedTab}>
             <Tab title="Redeem cash">
               <InputWrapper>
                 <TextInput

--- a/src/components/ToggleButton/index.js
+++ b/src/components/ToggleButton/index.js
@@ -59,14 +59,14 @@ class ToggleButton extends PureComponent {
     isActive: false
   };
 
-  handleButtonClicked = () => {
+  handleButtonClicked = e => {
     const { disabled } = this.props;
 
     if (disabled) return;
 
     this.setState(
       { isActive: !this.state.isActive },
-      this.props.onButtonClicked(!this.state.isActive)
+      this.props.onButtonClicked(!this.state.isActive, e)
     );
   };
 


### PR DESCRIPTION
Changes:
1. Make `activeIndex` prop of Tabs component to work as initial index of active tab, as it was before release 10.6
2. Add optional `controlledActiveIndex` prop to enable to switch between tabs from outside the Tabs component.
3. Make `onButtonClicked` prop of ToggleButton to receive click event object as second argument for more control of it from outside the component (e.g. for stopping event bubbling, getting the event target etc.)