### PR TITLE
Mitch/side nav target support

### DIFF
--- a/src/components/SideNav/index.js
+++ b/src/components/SideNav/index.js
@@ -1,5 +1,5 @@
 import PropTypes from 'prop-types';
-import React, { Component } from 'react';
+import React, { Component, Fragment } from 'react';
 import styled from 'styled-components';
 import { colors } from '../../styles/defaults';
 import Icon from '../atoms/Icon/Icon';
@@ -140,9 +140,9 @@ class SideNav extends Component {
               {logoUrl &&
                 (renderLink ? (
                   renderLink(
-                    <a>
+                    <Fragment>
                       <Logo src={logoUrl} />
-                    </a>,
+                    </Fragment>,
                     '/'
                   )
                 ) : (
@@ -155,14 +155,14 @@ class SideNav extends Component {
                   <ListItem key={`snav-${i}`} selected={item.isSelected}>
                     {renderLink ? (
                       renderLink(
-                        <Link>
+                        <Fragment>
                           {item.icon && <Icon name={item.icon} />}
                           {!iconsOnly && <span>{item.title}</span>}
-                        </Link>,
+                        </Fragment>,
                         item.pathname
                       )
                     ) : (
-                      <Link href={item.pathname}>
+                      <Link href={item.pathname} target={item.target ? item.target : "_self"}>
                         {item.icon && <Icon name={item.icon} />}
                         {!iconsOnly && <span>{item.title}</span>}
                       </Link>
@@ -233,6 +233,13 @@ SideNav.defaultProps = {
       pathname: '/premium',
       isSelected: false,
       icon: 'money'
+    },
+    {
+      title: 'Support',
+      pathname: 'https://support.capitalontap.com/en/support/home',
+      isSelected: false,
+      icon: 'help',
+      target: '_blank'
     }
   ],
   iconsOnly: false,

--- a/src/components/SideNav/index.js
+++ b/src/components/SideNav/index.js
@@ -151,24 +151,30 @@ class SideNav extends Component {
                   </a>
                 ))}
               <List>
-                {navItems.map((item, i) => (
-                  <ListItem key={`snav-${i}`} selected={item.isSelected}>
-                    {renderLink ? (
-                      renderLink(
-                        <Fragment>
+                {navItems.map((item, i) => {
+                  if (item.target === '_blank' && item.rel === undefined) {
+                    // Set rel tp prevent "reverse tabnabbing" in older browsers, can be overridden if needed
+                    item.rel = 'noopener noreferrer';
+                  }
+                  return (
+                    <ListItem key={`snav-${i}`} selected={item.isSelected}>
+                      {renderLink ? (
+                        renderLink(
+                          <Fragment>
+                            {item.icon && <Icon name={item.icon} />}
+                            {!iconsOnly && <span>{item.title}</span>}
+                          </Fragment>,
+                          item.pathname
+                        )
+                      ) : (
+                        <Link href={item.pathname} target={item.target} rel={item.rel}>
                           {item.icon && <Icon name={item.icon} />}
                           {!iconsOnly && <span>{item.title}</span>}
-                        </Fragment>,
-                        item.pathname
-                      )
-                    ) : (
-                      <Link href={item.pathname} target={item.target ? item.target : "_self"}>
-                        {item.icon && <Icon name={item.icon} />}
-                        {!iconsOnly && <span>{item.title}</span>}
-                      </Link>
-                    )}
-                  </ListItem>
-                ))}
+                        </Link>
+                      )}
+                    </ListItem>
+                  )
+                })}
               </List>
             </Content>
           </Nav>
@@ -186,8 +192,11 @@ SideNav.propTypes = {
   navItems: PropTypes.arrayOf(
     PropTypes.shape({
       title: PropTypes.string,
-      url: PropTypes.string,
-      isSelected: PropTypes.bool
+      pathname: PropTypes.string,
+      isSelected: PropTypes.bool,
+      icon: PropTypes.string,
+      target: PropTypes.string,
+      rel: PropTypes.string
     })
   ),
   iconsOnly: PropTypes.bool,

--- a/src/components/SideNav/index.js
+++ b/src/components/SideNav/index.js
@@ -153,7 +153,7 @@ class SideNav extends Component {
               <List>
                 {navItems.map((item, i) => {
                   if (item.target === '_blank' && item.rel === undefined) {
-                    // Set rel tp prevent "reverse tabnabbing" in older browsers, can be overridden if needed
+                    // Set rel to prevent "reverse tabnabbing" in older browsers, can be overridden if needed
                     item.rel = 'noopener noreferrer';
                   }
                   return (

--- a/src/components/SideNav/index.js
+++ b/src/components/SideNav/index.js
@@ -162,7 +162,7 @@ class SideNav extends Component {
                     item.rel = 'noopener noreferrer';
                   }
                   return (
-                    <ListItem key={`snav-${i}`} selected={item.isSelected}>
+                    <ListItem key={`snav-${item.pathname}`} selected={item.isSelected}>
                       {renderLink ? (
                         renderLink(
                           <Fragment>

--- a/src/components/SideNav/index.js
+++ b/src/components/SideNav/index.js
@@ -20,7 +20,7 @@ const List = styled.ul`
 
 const ListItem = styled.li`
   display: flex;
-  align-items: center;
+  align-items: left;
   color: ${props => (props.selected ? colors.primary : colors.darkGrey)};
   padding: 1rem;
   background-color: ${props => (props.selected ? colors.lightGrey : null)};
@@ -29,12 +29,15 @@ const ListItem = styled.li`
   a {
     text-decoration: none;
     color: inherit;
+    height: 100%;
+    width: 100%;
+    :hover {
+      color: ${colors.primary}
+    }
   }
   i {
     color: inherit;
-  }
-  > a:hover {
-    color: ${colors.primary}
+    margin-right:4px;
   }
 `;
 
@@ -47,7 +50,6 @@ const Logo = styled.img`
 const Link = styled.a`
   display: flex;
   align-items: center;
-  justify-content: space-between;
   > span ~ i {
     padding-right: 1rem;
   }

--- a/src/components/SideNav/index.js
+++ b/src/components/SideNav/index.js
@@ -33,6 +33,9 @@ const ListItem = styled.li`
   i {
     color: inherit;
   }
+  > a:hover {
+    color: ${colors.primary}
+  }
 `;
 
 const Logo = styled.img`


### PR DESCRIPTION
- Prevent empty a tags from being rendered when a renderLink function is provided to SideNav - this causes the following warning when passing a custom renderLink function:
_Warning: validateDOMNesting(...): <a> cannot appear as a descendant of <a>_
- Allow target and rel attributes to be set on navItems. If target is set to '_blank' and rel is left undefined then it will default to 'noopener noreferrer' to prevent reverse tabnabbing.
- Update PropTypes for navItems, may want to consider marking title and pathname as required.